### PR TITLE
fix: Change watch logic when route params changed

### DIFF
--- a/pages/_feed/_page.vue
+++ b/pages/_feed/_page.vue
@@ -67,7 +67,13 @@ export default {
   },
 
   watch: {
-    page: 'pageChanged'
+    '$route.params' (newParams, oldParams) {
+      if (newParams.feed !== oldParams.feed) {
+        this.$fetch()
+      }
+
+      this.pageChanged(newParams.page)
+    }
   },
 
   mounted () {


### PR DESCRIPTION
Current issue: When navigating to other feed page, error occurs and there's no new api called.

We should call fetch hook again after feed changes, and of course, prefetch the next page as before.

This PR may fix the issue. Thanks! 🎉