### PR TITLE
a11y: add title for score

### DIFF
--- a/components/Item.vue
+++ b/components/Item.vue
@@ -8,7 +8,7 @@ defineProps<{
 
 <template>
   <li class="news-item">
-    <span class="score">{{ item.points }}</span>
+    <span class="score" title="Score">{{ item.points }}</span>
     <span class="title">
       <template v-if="isAbsolute(item.url)">
         <a :href="item.url" target="_blank" rel="noopener">{{ item.title }}</a>


### PR DESCRIPTION
Added `score` title in the `Item.vue` component. 

There's no description about what the number stands for, so the title property might help.