### PR TITLE
build: add docker file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+node_modules
+npm-debug.log
+.git
+.gitignore
+*.md
+.eslintrc
+.dockerignore
+LICENSE
+netlify.toml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM node:alpine AS base
+COPY . /app-tmp
+WORKDIR /app-tmp
+
+FROM base AS build
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+RUN corepack enable && corepack use pnpm@8.14.0 && mkdir /app && pnpm run build
+
+FROM base
+COPY  --from=build /app-tmp/.output /app
+WORKDIR /app
+RUN rm -rf /app-tmp && rm -rf /pnpm
+ENV NUXT_HOST=0.0.0.0
+ENV NUXT_PORT=3000
+
+EXPOSE 3000
+
+ENTRYPOINT ["node", "server/index.mjs"]


### PR DESCRIPTION
Add docker file.
I can't find docker file in all official repositories, I don't know which the best way is to build a nuxt project to a docker image.
So I add dockerfile to this repo and tested:
- with node:alpine image size ~ 150mb
- with node:slim image size ~216mb

But there are two points I am not satisfied with this config:
- I am not sure this is the best way to build a nuxt project. Ie: build project in a folder and move the output to a new folder, and delete previous one.
- with non-root user, the image size reached to 1.2gb.

Anyone who can help with this PR is welcome!