### PR TITLE
fix: reactive header in user page

### DIFF
--- a/pages/user/[id].vue
+++ b/pages/user/[id].vue
@@ -6,7 +6,7 @@ const result = await fetchUser(id.value)
 const { data: user, loading } = toRefs(result)
 
 useHead({
-  title: loading.value
+  title: () => loading.value
     ? 'Loading'
     : user.value
       ? user.value.id


### PR DESCRIPTION
![image](https://github.com/nuxt/hackernews/assets/70888488/8c6937f6-aa8a-460a-8b0b-e61266dee98e)

![image](https://github.com/nuxt/hackernews/assets/70888488/65a7e839-be03-4f60-a246-d475dfefd072)


For example, in the news page,  when enter a user page by click the name. The header of the user page is not reactive event when the user data is loaded.

Follow by [unhead](https://unhead.unjs.io/setup/vue/best-practices)
