### PR TITLE
chore: prefer `nuxt` over `nuxi`

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     }
   ],
   "scripts": {
-    "dev": "nuxi dev",
-    "build": "nuxi build",
-    "start": "nuxi start",
+    "dev": "nuxt dev",
+    "build": "nuxt build",
+    "start": "nuxt start",
     "lint": "eslint ."
   },
   "devDependencies": {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description


this follows up on https://github.com/nuxt/nuxt/pull/32237 to use `nuxt` command consistently now that we no longer need compatibility with nuxt 2.